### PR TITLE
Add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "claude-code-mqtt",
+  "owner": {
+    "name": "Matt Stein"
+  },
+  "metadata": {
+    "description": "MQTT channel plugin for Claude Code - cross-session messaging, Home Assistant, and IoT bridge"
+  },
+  "plugins": [
+    {
+      "name": "mqtt",
+      "source": "./",
+      "description": "MQTT channel plugin - bridges MQTT messages into Claude Code sessions for cross-session communication, Home Assistant integration, and IoT workflows",
+      "version": "0.2.0"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds the marketplace index required for Claude Code's plugin install command to discover plugins in this repository.

The `plugin install name@repo` syntax treats the repo as a marketplace and looks for `.claude-plugin/marketplace.json` to find available plugins. Without this file, the install fails with "Plugin not found in marketplace."

## Changes
- `.claude-plugin/marketplace.json` - marketplace catalog indexing the "mqtt" plugin at the repo root

## Usage after merge
```bash
claude plugin install mqtt@mattstein111/claude-code-mqtt
```

## Test plan
- [ ] Verify `claude plugin install mqtt@mattstein111/claude-code-mqtt` succeeds
- [ ] Verify `claude plugin validate .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)